### PR TITLE
json_decode fix

### DIFF
--- a/src/Codesleeve/Sprockets/StaticFilesGenerator.php
+++ b/src/Codesleeve/Sprockets/StaticFilesGenerator.php
@@ -25,7 +25,7 @@ class StaticFilesGenerator implements Interfaces\StaticFilesGeneratorInterface
         $cache = $this->parser->config['cache_server'];
 
         $this->written = array();
-        $this->manifest = $cache->has($key) ? json_decode($cache->get($key)) : array();
+        $this->manifest = $cache->has($key) ? json_decode($cache->get($key), true) : array();
 
         foreach ($paths as $path)
         {


### PR DESCRIPTION
json_decode on line 28 is currently returning a stdClass rather than an array, setting the second argument to true fixes this and allows the array_merge on line 33 to work the second time around once assets:generate has been used.

Also, please see the [Pull request submitted by SerafimArts](https://github.com/CodeSleeve/asset-pipeline/pull/218) as this fixes assets:generate along with this pull request.

Thanks :)
